### PR TITLE
Reorder include directives to avoid naming conflicts.

### DIFF
--- a/src/model/SdeSimulation.cpp
+++ b/src/model/SdeSimulation.cpp
@@ -10,12 +10,12 @@
  *****************************************************************************/
 
 #include <cmath> 
-#include <R_ext/Error.h>
-#include <R_ext/Print.h>
-#include <Rinternals.h>
 //#include <Eigen/Dense>
 
 #include "EpochSimulation.h"
+#include <R_ext/Error.h>
+#include <R_ext/Print.h>
+#include <Rinternals.h>
 #include "EffectInfo.h"
 #include "SdeSimulation.h"
 #include "model/Model.h"

--- a/src/model/ml/Chain.cpp
+++ b/src/model/ml/Chain.cpp
@@ -7,11 +7,12 @@
  *
  * Description: This file contains the implementation of the class Chain.
  *****************************************************************************/
-#include <Rinternals.h>
 
 #include <vector>
 #include <stdexcept>
 #include <string>
+
+#include <Rinternals.h>
 
 #include "Chain.h"
 #include "utils/Utils.h"

--- a/src/model/ml/MLSimulation.cpp
+++ b/src/model/ml/MLSimulation.cpp
@@ -11,8 +11,9 @@
 #include <stdexcept>
 #include <string>
 #include <cmath>
-#include <Rinternals.h>
 #include "MLSimulation.h"
+
+#include <Rinternals.h>
 #include "utils/Random.h"
 #include "utils/Utils.h"
 #include "network/Network.h"

--- a/src/model/variables/BehaviorVariable.cpp
+++ b/src/model/variables/BehaviorVariable.cpp
@@ -12,11 +12,11 @@
 #include <cmath>
 #include <string>
 #include <stdexcept>
-#include <R_ext/Print.h>
-#include <R_ext/Arith.h>
-#include <Rinternals.h>
 #include "data/ActorSet.h"
 #include "utils/Random.h"
+#include <Rinternals.h>
+#include <R_ext/Print.h>
+#include <R_ext/Arith.h>
 #include "BehaviorVariable.h"
 #include "data/BehaviorLongitudinalData.h"
 #include "model/EpochSimulation.h"

--- a/src/model/variables/NetworkVariable.cpp
+++ b/src/model/variables/NetworkVariable.cpp
@@ -8,12 +8,12 @@
  * Description: This file contains the implementation of the
  * NetworkVariable class.
  *****************************************************************************/
-#include <R_ext/Print.h>
-#include <R_ext/Arith.h>
-#include <Rinternals.h>
 #include <algorithm>
 #include <vector>
 #include <cmath>
+#include <R_ext/Print.h>
+#include <R_ext/Arith.h>
+#include <Rinternals.h>
 #include "NetworkVariable.h"
 #include "network/NetworkUtils.h"
 #include "utils/Utils.h"

--- a/src/siena07setup.cpp
+++ b/src/siena07setup.cpp
@@ -14,7 +14,6 @@
  * Sets up the Data object with data from R
  */
 
-#include "siena07setup.h"
 
 #include <vector>
 #include <cstring>
@@ -23,6 +22,8 @@
 #include <R_ext/Print.h>
 #include <R_ext/Error.h>
 #include <Rinternals.h>
+
+#include "siena07setup.h"
 #include "siena07internals.h"
 #include "siena07utilities.h"
 #include "data/Data.h"


### PR DESCRIPTION
Please note the problem described in [Writing R Extensions](https://cran.r-project.org/doc/manuals/R-exts.html#The-R-API) re automatic symbol re-mapping. It is important to include system headers before R headers, so that the system headers are not subjected to the re-mapping. I've ran into this problem when compiling on Windows using LLVM 17, but now I see the same problems happen when compiling using clang on [Linux[(https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-clang/RSiena-00install.html):

```
In file included from siena07setup.cpp:19:
In file included from /usr/local/clang18/bin/../include/c++/v1/vector:325:
In file included from /usr/local/clang18/bin/../include/c++/v1/__format/formatter_bool.h:20:
In file included from /usr/local/clang18/bin/../include/c++/v1/__format/formatter_integral.h:35:
In file included from /usr/local/clang18/bin/../include/c++/v1/locale:202:
/usr/local/clang18/bin/../include/c++/v1/__locale:804:28: error: too many arguments provided to function-like macro invocation
  804 |   length(state_type& __st, const extern_type* __frm, const extern_type* __end, size_t __mx) const {
      |                            ^
/data/gannet/ripley/R/R-clang/include/Rinternals.h:975:9: note: macro 'length' defined here
  975 | #define length(x)               Rf_length(x)
```
This patch does some basic re-ordering which fixes the build on LLVM 17 (on Windows/aarch64).
