### PR TITLE
Added functions to extract expected probabilities

### DIFF
--- a/R/sienaMargins.r
+++ b/R/sienaMargins.r
@@ -231,17 +231,17 @@ message('\nNote that for symmetric networks, effect sizes are for modelType 2 (f
 				}
 				distributions <- apply(cdec, 3,
 					calculateChoiceProbability, theta[which(currentDepEffs)])
-				if (networkTypes[eff] == "behavior")
-				{
-					toggleProbabilities[,,w] <-
-						t(vapply(distributions, function(x){x[1,]}, rep(0,3)))
-				}
-				else
-				{
-					toggleProbabilities[,,w] <-
-						t(vapply(distributions, function(x){x[1,]}, rep(0,choices)))
-				}
-			}
+			# 	if (networkTypes[eff] == "behavior")
+			# 	{
+			# 		toggleProbabilities[,,w] <-
+			# 			t(vapply(distributions, function(x){x[1,]}, rep(0,3)))
+			# 	}
+			# 	else
+			# 	{
+			# 		toggleProbabilities[,,w] <-
+			# 			t(vapply(distributions, function(x){x[1,]}, rep(0,choices)))
+			# 	}
+			# }
 		}
 	}
 distributions                                             

--- a/R/sienaMargins.r
+++ b/R/sienaMargins.r
@@ -1,0 +1,237 @@
+#/******************************************************************************
+# * SIENA: Simulation Investigation for Empirical Network Analysis
+# *
+# * Web: https://www.stats.ox.ac.uk/~snijders/siena/
+# *
+# * File: sienaMargins.r
+# *
+# * Description: Used to calculate predicted edge probabilities, to be extended to 
+# * calculate (average) marginal effects
+# *****************************************************************************/
+
+## We might try to use RSiena:::getTargets() with returnStaticCHangeContribution = TRUE?
+
+
+# ##@getChangeContributions. Use as RSiena:::getChangeContributions
+# getChangeContributions <- function(algorithm, data, effects)
+# {
+# 	## Gets the simulated statistics.
+# 	## The following initializations data, effects, and model
+# 	## for calling "getTargets" in "siena07.setup.h"
+# 	## is more or less copied from "getTargets" in "getTargets.r".
+# 	## However, some modifications have been necessary to get it to work.
+# 	f <- unpackData(data,algorithm)
+
+# 	effects <- effects[effects$include,]
+# 	if (!is.null(algorithm$settings))
+# 	{
+# 		stop('not implemented: RI together with settings')
+# 		# effects <- addSettingsEffects(effects, algorithm)
+# 	}
+# 	else
+# 	{
+# 		effects$setting <- rep("", nrow(effects))
+# 	}
+# 	pData <- .Call(C_setupData, PACKAGE=pkgname,
+# 		list(as.integer(f$observations)),
+# 		list(f$nodeSets))
+# 	## register a finalizer
+# 	ans <- reg.finalizer(pData, clearData, onexit = FALSE)
+# 	ans<- .Call(C_OneMode, PACKAGE=pkgname,
+# 		pData, list(f$nets))
+# 	ans <- .Call(C_Bipartite, PACKAGE=pkgname, # added 1.1-299
+# 		pData, list(f$bipartites))
+# 	ans<- .Call(C_Behavior, PACKAGE=pkgname, pData,
+# 		list(f$behavs))
+# 	ans<-.Call(C_ConstantCovariates, PACKAGE=pkgname,
+# 		pData, list(f$cCovars))
+# 	ans<-.Call(C_ChangingCovariates,PACKAGE=pkgname,
+# 		pData,list(f$vCovars))
+# 	ans<-.Call(C_DyadicCovariates,PACKAGE=pkgname,
+# 		pData,list(f$dycCovars))
+# 	ans<-.Call(C_ChangingDyadicCovariates,PACKAGE=pkgname,
+# 		pData, list(f$dyvCovars))
+
+# 	storage.mode(effects$parm) <- 'integer'
+# 	storage.mode(effects$group) <- 'integer'
+# 	storage.mode(effects$period) <- 'integer'
+
+# 	effects$effectPtr <- rep(NA, nrow(effects))
+# 	depvarnames <- names(data$depvars)
+# 	tmpeffects <- split(effects, effects$name)
+# 	myeffectsOrder <- match(depvarnames, names(tmpeffects))
+# 	ans <- .Call(C_effects, PACKAGE=pkgname, pData, tmpeffects)
+# 	pModel <- ans[[1]][[1]]
+# 	for (i in 1:seq_along((ans[[2]])))
+# 	{
+# 		effectPtr <- ans[[2]][[i]]
+# 		tmpeffects[[i]]$effectPtr <- effectPtr
+# 	}
+# 	myeffects <- tmpeffects
+# 	for(i in 1:seq_along((myeffectsOrder)){
+# 		myeffects[[i]]<-tmpeffects[[myeffectsOrder[i]]]
+# 	}
+# 	ans <- .Call(C_getTargets, PACKAGE=pkgname, pData, pModel, myeffects,
+# 		parallelrun=TRUE, returnActorStatistics=FALSE,
+# 		returnStaticChangeContributions=TRUE)
+# 	# See getTargets in siena07setup.cpp; also see rTargets in StatisticsSimulation.cpp
+# 	ans
+# }
+
+# calculateDistributions <- function(effectContributions = NULL, theta = NULL)
+# {
+# 	neffects <- dim(effectContributions)[1]
+# 	nchoices <- dim(effectContributions)[2]
+# 	distributions <- array(NA, dim = c(neffects+1,nchoices))
+# 	the.choices <- !is.na(colSums(effectContributions))
+# 	if (sum(the.choices) >= 2)
+# 	{
+# 		distributions[1,the.choices] <-
+# 			exp(colSums(theta*effectContributions[,the.choices,drop=FALSE], na.rm=TRUE))/
+# 			sum(exp(colSums(theta*effectContributions[,the.choices,drop=FALSE], na.rm=TRUE)))
+# 		for(eff in 1:neffects)
+# 		{
+# 			th <- theta
+# 			th[eff] <- 0
+# 			distributions[eff+1,the.choices] <-
+# 				exp(colSums(th*effectContributions[,the.choices,drop=FALSE], na.rm=TRUE))/
+# 				sum(exp(colSums(th*effectContributions[,the.choices,drop=FALSE], na.rm=TRUE)))
+# 		}
+# 	}
+# 	distributions
+# }
+
+## Are these the change probabilities or the tie probabilities?
+
+##@expectedChangeProbabilities. Use as RSiena:::expectedChangeProbabilities
+expectedChangeProbabilities <- function(conts, effects, theta, thedata=NULL, effectNames = NULL)
+{
+	rms <- function(xx){sqrt((1/dim(xx)[2])*rowSums(xx^2,na.rm=TRUE))}
+	waves <- length(conts[[1]])
+	effects <- effects[effects$include == TRUE,]
+	noRate <- effects$type != "rate"
+	effects <- effects[noRate,]
+	if(sum(noRate)!=length(theta))
+	{
+		theta <- theta[noRate]
+	}
+	effectNa <- attr(conts,"effectNames")
+	effectTypes <- attr(conts,"effectTypes")
+	networkNames <- attr(conts,"networkNames")
+	networkTypes <- attr(conts,"networkTypes")
+	networkInteraction <- effects$interaction1
+	effectIds <- paste(effectNa,effectTypes,networkInteraction, sep = ".")
+	currentDepName <- ""
+	depNumber <- 0
+	for(eff in 1:length(effectIds))
+	{
+		if(networkNames[eff] != currentDepName)
+		{
+			currentDepName <- networkNames[eff]
+			actors <- length(conts[[1]][[1]][[1]])
+			depNumber <- depNumber + 1
+			currentDepEffs <- effects$name == currentDepName
+			effNumber <- sum(currentDepEffs)
+			depNetwork <- thedata$depvars[[depNumber]]
+			if (networkTypes[eff] == "oneMode")
+			{
+				choices <- actors
+			}
+			else if (networkTypes[eff] == "behavior")
+			{
+				choices <- 3
+			}
+			else if (networkTypes[eff] == "bipartite")
+			{
+				if (dim(depNetwork)[2] >= actors)
+				{
+					stop("sienaRI does not work for bipartite networks with second mode >= first mode")
+				}
+				choices <- dim(depNetwork)[2] + 1
+			}
+			else
+			{
+				stop("sienaRI does not work for dependent variables of type 'continuous'")
+			}
+
+			# impute for wave 1
+			if (networkTypes[eff] %in% c("oneMode", "bipartite"))
+			{
+				depNetwork[,,1][is.na(depNetwork[,,1])] <- 0
+			}
+			else
+			{
+				depNetwork[,,1][is.na(depNetwork[,,1])] <- attr(depNetwork, 'modes')[1]
+			}
+			# impute for next waves;
+			# this may be undesirable for structurals immediately followed by NA...
+			for (m in 2:dim(depNetwork)[3]){depNetwork[,,m][is.na(depNetwork[,,m])] <-
+				depNetwork[,,m-1][is.na(depNetwork[,,m])]}
+				# Make sure the diagonals are not treated as structurals
+				if (networkTypes[eff] == "oneMode")
+				{
+					for (m in 1:(dim(depNetwork)[3])){diag(depNetwork[,,m]) <- 0}
+				}
+			structurals <- (depNetwork >= 10)
+			if (networkTypes[eff] == "oneMode"){
+				if (attr(depNetwork, 'symmetric')){
+message('\nNote that for symmetric networks, effect sizes are for modelType 2 (forcing).')}}
+
+			#			currentDepObjEffsNames <- paste(effects$shortName[currentDepEffs],
+			#				effects$type[currentDepEffs],effects$interaction1[currentDepEffs],sep=".")
+			#			otherObjEffsNames <- paste(effects$shortName[!currentDepEffs],
+			#				effects$type[!currentDepEffs],effects$interaction1[!currentDepEffs],sep=".")
+
+			absoluteSumActors <- list()
+			RHActors <-list()
+			changeStats <-list()
+			sigma <- list()
+			sigmas <- matrix(NA, sum(currentDepEffs), waves)
+			for(w in 1:waves)
+			{
+				currentDepEffectContributions <- conts[[1]][[w]][currentDepEffs]
+				if (networkTypes[eff] == "bipartite")
+				{
+					currentDepEffectContributions <- lapply(
+							currentDepEffectContributions,
+							function(x){lapply(x,function(xx){xx[1:choices]})})
+				}
+				# conts[[1]] is periods by effects by actors by actors
+				currentDepEffectContributions <-
+					sapply(lapply(currentDepEffectContributions, unlist),
+						matrix, nrow=actors, ncol=choices, byrow=TRUE,
+						simplify="array")
+				cdec <- apply(currentDepEffectContributions, c(2,1), as.matrix)
+				# cdec is effects by actors (alters) by actors (egos)
+				if (dim(currentDepEffectContributions)[3] <= 1) # only one effect
+				{
+					cdec <- array(cdec, dim=c(1,dim(cdec)))
+				}
+##
+				rownames(cdec) <- effectNa[currentDepEffs]
+				if (getChangeStatistics)
+				{
+					changeStats[[w]] <- cdec
+				}
+				# replace structural 0s and 1s by NA,
+				# so they are omitted from calculation of RI, R_H, sigma
+				if (networkTypes[eff] == "oneMode")
+				{
+					#	structuralsw <- structurals[,,w]
+					for (ff in 1:(dim(cdec)[1])){cdec[ff,,][t(structurals[,,w])] <- NA}
+				}
+				distributions <- apply(cdec, 3,
+					calculateDistributions, theta[which(currentDepEffs)])
+
+				# distributions is a list, length = number of actors
+				# distributions[[i]] is for actor i, a matrix of dim (effects + 1) * (actors as alters)
+				# giving the probability of toggling the tie variable to the alters;
+				# the first row is for the unchanged parameter vector theta,
+				# each of the following has put one element of theta to 0.
+				# for behavior it is a matrix of dim (effects + 1) * 3
+distributions
+}
+
+## we probably want to extract a tie probability matrix from this
+
+## we should also be able to use code from SienaRIDynamics to calculate the expected probabilitie for each simulation step

--- a/R/sienaMargins.r
+++ b/R/sienaMargins.r
@@ -9,38 +9,37 @@
 # * calculate (average) marginal effects
 # *****************************************************************************/
 
-## Currently uses getChangeContribution from RIsiena.R
-## We might try to use RSiena:::getTargets() with returnStaticCHangeContribution = TRUE?
+# Currently uses getChangeContribution from RIsiena.R
+# We might try to use RSiena:::getTargets() with returnStaticCHangeContribution = TRUE?
 
 
 
 ##@softmax Recursive softmax formula, see https://rpubs.com/FJRubio/softmax. Use as RSiena:::softmax
-softmax <- function(par, recursive = FALSE){
+softmax <- function(par = NULL, recursive = TRUE) {
   if (recursive == TRUE) {
     n.par <- length(par)
     par1 <- sort(par, decreasing = TRUE)
     Lk <- par1[1]
-    for (k in 1:(n.par-1)) {
-      Lk <- max(par1[k+1], Lk) + log1p(exp(-abs(par1[k+1] - Lk)))
+    for (k in 1:(n.par - 1)) {
+      Lk <- max(par1[k + 1], Lk) + log1p(exp(-abs(par1[k + 1] - Lk)))
     }
     val <- exp(par - Lk)
-    val
+  } else {
+    val <- exp(par) / sum(exp(par))
   }
-  else {
-  val <- exp(par) /
-    sum(exp(par))
-  }
+  val
 }
 
 ##@calculateChoiceProbability. Use as RSiena:::calculateChoiceProbability (just a simplified calculateDistribution)
-calculateChoiceProbability <- function(effectContributions = NULL, theta = NULL)
-{
+# Calculate the probability of each potential choice for the focal actor
+calculateChoiceProbability <- function(effectContributions = NULL, theta = NULL) {
   nchoices <- dim(effectContributions)[2]
-  distributions <- array(NA, dim = c(1,nchoices)) #probably could also work with a simple vector
+  distributions <- array(NA, dim = c(1, nchoices)) # probably could also work with a simple vector
   the.choices <- !is.na(colSums(effectContributions))
-  if (sum(the.choices) >= 2) { ## should produce an error instead of an empty array?
-    utilitiy <- colSums(theta*effectContributions[,the.choices,drop = FALSE], na.rm = TRUE) # why not theta %*% effectContributions[,the.choices,drop = FALSE] ?
-    distributions[1,the.choices] <- softmax(utilitiy)
+  if (sum(the.choices) >= 2) { # should produce an error instead of an empty array?
+    utilitiy <- colSums(theta * effectContributions[, the.choices, drop = FALSE], na.rm = TRUE)
+    # why not theta %*% effectContributions[,the.choices,drop = FALSE] ?
+    distributions[1, the.choices] <- softmax(utilitiy)
   }
   distributions # returns the choice probabilitiy for the focal actor
 }
@@ -49,21 +48,21 @@ calculateChoiceProbability <- function(effectContributions = NULL, theta = NULL)
 expectedChangeProbabilities <- function(conts, effects, theta, thedata = NULL, 
                                         getChangeStatistics = FALSE, effectNames = NULL) {
   waves <- length(conts[[1]])
-  effects <- effects[effects$include == TRUE,]
+  effects <- effects[effects$include == TRUE, ]
   noRate <- effects$type != "rate"
-  effects <- effects[noRate,]
-  if(sum(noRate) != length(theta)) {
+  effects <- effects[noRate, ]
+  if (sum(noRate) != length(theta)) {
     theta <- theta[noRate]
   }
-  effectNa <- attr(conts,"effectNames")
-  effectTypes <- attr(conts,"effectTypes")
-  networkNames <- attr(conts,"networkNames")
-  networkTypes <- attr(conts,"networkTypes")
+  effectNa <- attr(conts, "effectNames")
+  effectTypes <- attr(conts, "effectTypes")
+  networkNames <- attr(conts, "networkNames")
+  networkTypes <- attr(conts, "networkTypes")
   networkInteraction <- effects$interaction1
-  effectIds <- paste(effectNa,effectTypes,networkInteraction, sep = ".")
+  effectIds <- paste(effectNa, effectTypes, networkInteraction, sep = ".")
   currentDepName <- ""
   depNumber <- 0
-  for(eff in 1:length(effectIds)) {
+  for(eff in 1:seq_along(effectIds)) {
     if(networkNames[eff] != currentDepName) {
       currentDepName <- networkNames[eff]
       actors <- length(conts[[1]][[1]][[1]])
@@ -72,55 +71,47 @@ expectedChangeProbabilities <- function(conts, effects, theta, thedata = NULL,
       depNetwork <- thedata$depvars[[depNumber]]
       if (networkTypes[eff] == "oneMode") {
         choices <- actors
-      }
-      else if (networkTypes[eff] == "behavior") {
+      } else if (networkTypes[eff] == "behavior") {
         choices <- 3
-      }
-      else if (networkTypes[eff] == "bipartite") {
+      } else if (networkTypes[eff] == "bipartite") {
         if (dim(depNetwork)[2] >= actors) {
           stop("does not work for bipartite networks with second mode >= first mode")
         }
         choices <- dim(depNetwork)[2] + 1
-      }
-      else {
+      } else {
         stop("does not work for dependent variables of type 'continuous'")
       }
-      
       # impute for wave 1
       if (networkTypes[eff] %in% c("oneMode", "bipartite")) {
-        depNetwork[,,1][is.na(depNetwork[,,1])] <- 0
-      }
-      else {
-        depNetwork[,,1][is.na(depNetwork[,,1])] <- attr(depNetwork, 'modes')[1]
+        depNetwork[, , 1][is.na(depNetwork[, , 1])] <- 0
+      } else {
+        depNetwork[, , 1][is.na(depNetwork[, , 1])] <- attr(depNetwork, "modes")[1]
       }
       # impute for next waves;
       # this may be undesirable for structurals immediately followed by NA...
       for (m in 2:dim(depNetwork)[3]) {
-        depNetwork[,,m][is.na(depNetwork[,,m])] <- depNetwork[,,m - 1][is.na(depNetwork[,,m])]
-        }
+        depNetwork[, , m][is.na(depNetwork[, , m])] <- depNetwork[, , m - 1][is.na(depNetwork[, , m])]
+      }
       # Make sure the diagonals are not treated as structurals
       if (networkTypes[eff] == "oneMode") {
         for (m in 1:(dim(depNetwork)[3])) {
-          diag(depNetwork[,,m]) <- 0
+          diag(depNetwork[, , m]) <- 0
         }
       }
       structurals <- (depNetwork >= 10)
       if (networkTypes[eff] == "oneMode") {
-        if (attr(depNetwork, 'symmetric')) {
-          message('\nNote that for symmetric networks, effect sizes are for modelType 2 (forcing).')
+        if (attr(depNetwork, "symmetric")) {
+          message("\nNote that for symmetric networks, effect sizes are for modelType 2 (forcing).")
         }
       }
-      
       #			currentDepObjEffsNames <- paste(effects$shortName[currentDepEffs],
       #				effects$type[currentDepEffs],effects$interaction1[currentDepEffs],sep=".")
       #			otherObjEffsNames <- paste(effects$shortName[!currentDepEffs],
       #				effects$type[!currentDepEffs],effects$interaction1[!currentDepEffs],sep=".")
-      
       changeStats <- list()
       if (networkTypes[eff] == "behavior") {
         toggleProbabilities <- array(0, dim = c(actors, 3, waves))
-      }
-      else {
+      } else {
         toggleProbabilities <- array(0, dim = c(actors, choices, waves))
       }
       for(w in 1:waves) {
@@ -128,18 +119,18 @@ expectedChangeProbabilities <- function(conts, effects, theta, thedata = NULL,
         if (networkTypes[eff] == "bipartite") {
           currentDepEffectContributions <- lapply(
             currentDepEffectContributions,
-            function(x){lapply(x,function(xx){xx[1:choices]})}
-            )
+            function(x) lapply(x, function(xx) xx[1:choices])
+          )
         }
         # conts[[1]] is periods by effects by actors by actors
         currentDepEffectContributions <-
           sapply(lapply(currentDepEffectContributions, unlist),
                  matrix, nrow = actors, ncol = choices, byrow = TRUE,
                  simplify = "array")
-        cdec <- apply(currentDepEffectContributions, c(2,1), as.matrix)
+        cdec <- apply(currentDepEffectContributions, c(2, 1), as.matrix)
         # cdec is effects by actors (alters) by actors (egos)
         if (dim(currentDepEffectContributions)[3] <= 1) { # only one effect
-          cdec <- array(cdec, dim = c(1,dim(cdec)))
+          cdec <- array(cdec, dim = c(1, dim(cdec)))
         }
         rownames(cdec) <- effectNa[currentDepEffs]
         if (getChangeStatistics) {
@@ -150,19 +141,22 @@ expectedChangeProbabilities <- function(conts, effects, theta, thedata = NULL,
         if (networkTypes[eff] == "oneMode") {
           #	structuralsw <- structurals[,,w]
           for (ff in 1:(dim(cdec)[1])) {
-            cdec[ff,,][t(structurals[,,w])] <- NA
+            cdec[ff, , ][t(structurals[, , w])] <- NA
           }
         }
         distributions <- apply(cdec, 3,
-                               calculateChoiceProbability, theta[which(currentDepEffs)]) # matrix manipulation should be more efficient solution
+                               calculateChoiceProbability, theta[which(currentDepEffs)])
+        # matrix manipulation should be more efficient solution
+        # distributions is an array of actor by choices
         if (networkTypes[eff] == "behavior") {
-          toggleProbabilities[,,w] <- t(distributions)
-        }
-        else {
-          toggleProbabilities[,,w] <- t(distributions)
+          toggleProbabilities[, , w] <- t(distributions)
+        } else {
+          toggleProbabilities[, , w] <- t(distributions)
         }
       }
     }
   }
-  toggleProbabilities                                             
+  # toggleProbabilities is an array of choices by actors by wave
+  attr(toggleProbabilities, "version") <- packageDescription(pkgname, fields = "Version")
+  toggleProbabilities
 }

--- a/R/sienaMargins.r
+++ b/R/sienaMargins.r
@@ -9,244 +9,160 @@
 # * calculate (average) marginal effects
 # *****************************************************************************/
 
+## Currently uses getChangeContribution from RIsiena.R
 ## We might try to use RSiena:::getTargets() with returnStaticCHangeContribution = TRUE?
 
 
-# ##@getChangeContributions. Use as RSiena:::getChangeContributions
-# getChangeContributions <- function(algorithm, data, effects)
-# {
-# 	## Gets the simulated statistics.
-# 	## The following initializations data, effects, and model
-# 	## for calling "getTargets" in "siena07.setup.h"
-# 	## is more or less copied from "getTargets" in "getTargets.r".
-# 	## However, some modifications have been necessary to get it to work.
-# 	f <- unpackData(data,algorithm)
-
-# 	effects <- effects[effects$include,]
-# 	if (!is.null(algorithm$settings))
-# 	{
-# 		stop('not implemented: RI together with settings')
-# 		# effects <- addSettingsEffects(effects, algorithm)
-# 	}
-# 	else
-# 	{
-# 		effects$setting <- rep("", nrow(effects))
-# 	}
-# 	pData <- .Call(C_setupData, PACKAGE=pkgname,
-# 		list(as.integer(f$observations)),
-# 		list(f$nodeSets))
-# 	## register a finalizer
-# 	ans <- reg.finalizer(pData, clearData, onexit = FALSE)
-# 	ans<- .Call(C_OneMode, PACKAGE=pkgname,
-# 		pData, list(f$nets))
-# 	ans <- .Call(C_Bipartite, PACKAGE=pkgname, # added 1.1-299
-# 		pData, list(f$bipartites))
-# 	ans<- .Call(C_Behavior, PACKAGE=pkgname, pData,
-# 		list(f$behavs))
-# 	ans<-.Call(C_ConstantCovariates, PACKAGE=pkgname,
-# 		pData, list(f$cCovars))
-# 	ans<-.Call(C_ChangingCovariates,PACKAGE=pkgname,
-# 		pData,list(f$vCovars))
-# 	ans<-.Call(C_DyadicCovariates,PACKAGE=pkgname,
-# 		pData,list(f$dycCovars))
-# 	ans<-.Call(C_ChangingDyadicCovariates,PACKAGE=pkgname,
-# 		pData, list(f$dyvCovars))
-
-# 	storage.mode(effects$parm) <- 'integer'
-# 	storage.mode(effects$group) <- 'integer'
-# 	storage.mode(effects$period) <- 'integer'
-
-# 	effects$effectPtr <- rep(NA, nrow(effects))
-# 	depvarnames <- names(data$depvars)
-# 	tmpeffects <- split(effects, effects$name)
-# 	myeffectsOrder <- match(depvarnames, names(tmpeffects))
-# 	ans <- .Call(C_effects, PACKAGE=pkgname, pData, tmpeffects)
-# 	pModel <- ans[[1]][[1]]
-# 	for (i in 1:seq_along((ans[[2]])))
-# 	{
-# 		effectPtr <- ans[[2]][[i]]
-# 		tmpeffects[[i]]$effectPtr <- effectPtr
-# 	}
-# 	myeffects <- tmpeffects
-# 	for(i in 1:seq_along((myeffectsOrder)){
-# 		myeffects[[i]]<-tmpeffects[[myeffectsOrder[i]]]
-# 	}
-# 	ans <- .Call(C_getTargets, PACKAGE=pkgname, pData, pModel, myeffects,
-# 		parallelrun=TRUE, returnActorStatistics=FALSE,
-# 		returnStaticChangeContributions=TRUE)
-# 	# See getTargets in siena07setup.cpp; also see rTargets in StatisticsSimulation.cpp
-# 	ans
-# }
 
 ##@softmax Recursive softmax formula, see https://rpubs.com/FJRubio/softmax. Use as RSiena:::softmax
-softmax <- function(par){
-#   n.par <- length(par)
-#   par1 <- sort(par, decreasing = TRUE)
-#   Lk <- par1[1]
-#   for (k in 1:(n.par-1)) {
-#     Lk <- max(par1[k+1], Lk) + log1p(exp(-abs(par1[k+1] - Lk))) 
-#   }
-#   val <- exp(par - Lk)
-#   return(val)
-exp(colSums(par, na.rm=TRUE))/
-			sum(exp(colSums(par, na.rm=TRUE)))
+softmax <- function(par, recursive = FALSE){
+  if (recursive == TRUE) {
+    n.par <- length(par)
+    par1 <- sort(par, decreasing = TRUE)
+    Lk <- par1[1]
+    for (k in 1:(n.par-1)) {
+      Lk <- max(par1[k+1], Lk) + log1p(exp(-abs(par1[k+1] - Lk)))
+    }
+    val <- exp(par - Lk)
+    val
+  }
+  else {
+  val <- exp(par) /
+    sum(exp(par))
+  }
 }
 
 ##@calculateChoiceProbability. Use as RSiena:::calculateChoiceProbability (just a simplified calculateDistribution)
 calculateChoiceProbability <- function(effectContributions = NULL, theta = NULL)
 {
-	nchoices <- dim(effectContributions)[2]
-	distributions <- array(NA, dim = c(1,nchoices))
-	the.choices <- !is.na(colSums(effectContributions))
-	if (sum(the.choices) >= 2) ## should produce an error instead of an empty array?
-	{
-		distributions[1,the.choices] <- softmax(theta*effectContributions[,the.choices,drop=FALSE])
-	}
-	distributions
+  nchoices <- dim(effectContributions)[2]
+  distributions <- array(NA, dim = c(1,nchoices)) #probably could also work with a simple vector
+  the.choices <- !is.na(colSums(effectContributions))
+  if (sum(the.choices) >= 2) { ## should produce an error instead of an empty array?
+    utilitiy <- colSums(theta*effectContributions[,the.choices,drop = FALSE], na.rm = TRUE) # why not theta %*% effectContributions[,the.choices,drop = FALSE] ?
+    distributions[1,the.choices] <- softmax(utilitiy)
+  }
+  distributions # returns the choice probabilitiy for the focal actor
 }
 
 ##@expectedChangeProbabilities. Use as RSiena:::expectedChangeProbabilities
-expectedChangeProbabilities <- function(conts, effects, theta, thedata=NULL, 
-	getChangeStatistics=FALSE, effectNames = NULL)
-{
-	waves <- length(conts[[1]])
-	effects <- effects[effects$include == TRUE,]
-	noRate <- effects$type != "rate"
-	effects <- effects[noRate,]
-	if(sum(noRate)!=length(theta))
-	{
-		theta <- theta[noRate]
-	}
-	effectNa <- attr(conts,"effectNames")
-	effectTypes <- attr(conts,"effectTypes")
-	networkNames <- attr(conts,"networkNames")
-	networkTypes <- attr(conts,"networkTypes")
-	networkInteraction <- effects$interaction1
-	effectIds <- paste(effectNa,effectTypes,networkInteraction, sep = ".")
-	currentDepName <- ""
-	depNumber <- 0
-	for(eff in 1:length(effectIds))
-	{
-		if(networkNames[eff] != currentDepName)
-		{
-			currentDepName <- networkNames[eff]
-			actors <- length(conts[[1]][[1]][[1]])
-			depNumber <- depNumber + 1
-			currentDepEffs <- effects$name == currentDepName
-			effNumber <- sum(currentDepEffs)
-			depNetwork <- thedata$depvars[[depNumber]]
-			if (networkTypes[eff] == "oneMode")
-			{
-				choices <- actors
-			}
-			else if (networkTypes[eff] == "behavior")
-			{
-				choices <- 3
-			}
-			else if (networkTypes[eff] == "bipartite")
-			{
-				if (dim(depNetwork)[2] >= actors)
-				{
-					stop("does not work for bipartite networks with second mode >= first mode")
-				}
-				choices <- dim(depNetwork)[2] + 1
-			}
-			else
-			{
-				stop("does not work for dependent variables of type 'continuous'")
-			}
-
-			# impute for wave 1
-			if (networkTypes[eff] %in% c("oneMode", "bipartite"))
-			{
-				depNetwork[,,1][is.na(depNetwork[,,1])] <- 0
-			}
-			else
-			{
-				depNetwork[,,1][is.na(depNetwork[,,1])] <- attr(depNetwork, 'modes')[1]
-			}
-			# impute for next waves;
-			# this may be undesirable for structurals immediately followed by NA...
-			for (m in 2:dim(depNetwork)[3]){depNetwork[,,m][is.na(depNetwork[,,m])] <-
-				depNetwork[,,m-1][is.na(depNetwork[,,m])]}
-				# Make sure the diagonals are not treated as structurals
-				if (networkTypes[eff] == "oneMode")
-				{
-					for (m in 1:(dim(depNetwork)[3])){diag(depNetwork[,,m]) <- 0}
-				}
-			structurals <- (depNetwork >= 10)
-			if (networkTypes[eff] == "oneMode"){
-				if (attr(depNetwork, 'symmetric')){
-message('\nNote that for symmetric networks, effect sizes are for modelType 2 (forcing).')}}
-
-			#			currentDepObjEffsNames <- paste(effects$shortName[currentDepEffs],
-			#				effects$type[currentDepEffs],effects$interaction1[currentDepEffs],sep=".")
-			#			otherObjEffsNames <- paste(effects$shortName[!currentDepEffs],
-			#				effects$type[!currentDepEffs],effects$interaction1[!currentDepEffs],sep=".")
-
-			absoluteSumActors <- list()
-			RHActors <-list()
-			changeStats <-list()
-			sigma <- list()
-			sigmas <- matrix(NA, sum(currentDepEffs), waves)
-			if (networkTypes[eff] == "behavior")
-			{
-				toggleProbabilities <- array(0, dim=c(actors, 3, waves))
-			}
-			else
-			{
-				toggleProbabilities <- array(0, dim=c(actors, choices, waves))
-			}
-			for(w in 1:waves)
-			{
-				currentDepEffectContributions <- conts[[1]][[w]][currentDepEffs]
-				if (networkTypes[eff] == "bipartite")
-				{
-					currentDepEffectContributions <- lapply(
-							currentDepEffectContributions,
-							function(x){lapply(x,function(xx){xx[1:choices]})})
-				}
-				# conts[[1]] is periods by effects by actors by actors
-				currentDepEffectContributions <-
-					sapply(lapply(currentDepEffectContributions, unlist),
-						matrix, nrow=actors, ncol=choices, byrow=TRUE,
-						simplify="array")
-				cdec <- apply(currentDepEffectContributions, c(2,1), as.matrix)
-				# cdec is effects by actors (alters) by actors (egos)
-				if (dim(currentDepEffectContributions)[3] <= 1) # only one effect
-				{
-					cdec <- array(cdec, dim=c(1,dim(cdec)))
-				}
-				rownames(cdec) <- effectNa[currentDepEffs]
-				if (getChangeStatistics)
-				{
-					changeStats[[w]] <- cdec
-				}
-				# replace structural 0s and 1s by NA,
-				# so they are omitted from calculation
-				if (networkTypes[eff] == "oneMode")
-				{
-					#	structuralsw <- structurals[,,w]
-					for (ff in 1:(dim(cdec)[1])){cdec[ff,,][t(structurals[,,w])] <- NA}
-				}
-				distributions <- apply(cdec, 3,
-					calculateChoiceProbability, theta[which(currentDepEffs)])
-			# 	if (networkTypes[eff] == "behavior")
-			# 	{
-			# 		toggleProbabilities[,,w] <-
-			# 			t(vapply(distributions, function(x){x[1,]}, rep(0,3)))
-			# 	}
-			# 	else
-			# 	{
-			# 		toggleProbabilities[,,w] <-
-			# 			t(vapply(distributions, function(x){x[1,]}, rep(0,choices)))
-			# 	}
-			# }
-		}
-	}
-distributions                                             
-}            
-
-## we probably want to extract a tie probability matrix from this
-
-## we should also be able to use code from SienaRIDynamics to calculate the expected probabilitie for each simulation step
+expectedChangeProbabilities <- function(conts, effects, theta, thedata = NULL, 
+                                        getChangeStatistics = FALSE, effectNames = NULL) {
+  waves <- length(conts[[1]])
+  effects <- effects[effects$include == TRUE,]
+  noRate <- effects$type != "rate"
+  effects <- effects[noRate,]
+  if(sum(noRate) != length(theta)) {
+    theta <- theta[noRate]
+  }
+  effectNa <- attr(conts,"effectNames")
+  effectTypes <- attr(conts,"effectTypes")
+  networkNames <- attr(conts,"networkNames")
+  networkTypes <- attr(conts,"networkTypes")
+  networkInteraction <- effects$interaction1
+  effectIds <- paste(effectNa,effectTypes,networkInteraction, sep = ".")
+  currentDepName <- ""
+  depNumber <- 0
+  for(eff in 1:length(effectIds)) {
+    if(networkNames[eff] != currentDepName) {
+      currentDepName <- networkNames[eff]
+      actors <- length(conts[[1]][[1]][[1]])
+      depNumber <- depNumber + 1
+      currentDepEffs <- effects$name == currentDepName
+      depNetwork <- thedata$depvars[[depNumber]]
+      if (networkTypes[eff] == "oneMode") {
+        choices <- actors
+      }
+      else if (networkTypes[eff] == "behavior") {
+        choices <- 3
+      }
+      else if (networkTypes[eff] == "bipartite") {
+        if (dim(depNetwork)[2] >= actors) {
+          stop("does not work for bipartite networks with second mode >= first mode")
+        }
+        choices <- dim(depNetwork)[2] + 1
+      }
+      else {
+        stop("does not work for dependent variables of type 'continuous'")
+      }
+      
+      # impute for wave 1
+      if (networkTypes[eff] %in% c("oneMode", "bipartite")) {
+        depNetwork[,,1][is.na(depNetwork[,,1])] <- 0
+      }
+      else {
+        depNetwork[,,1][is.na(depNetwork[,,1])] <- attr(depNetwork, 'modes')[1]
+      }
+      # impute for next waves;
+      # this may be undesirable for structurals immediately followed by NA...
+      for (m in 2:dim(depNetwork)[3]) {
+        depNetwork[,,m][is.na(depNetwork[,,m])] <- depNetwork[,,m - 1][is.na(depNetwork[,,m])]
+        }
+      # Make sure the diagonals are not treated as structurals
+      if (networkTypes[eff] == "oneMode") {
+        for (m in 1:(dim(depNetwork)[3])) {
+          diag(depNetwork[,,m]) <- 0
+        }
+      }
+      structurals <- (depNetwork >= 10)
+      if (networkTypes[eff] == "oneMode") {
+        if (attr(depNetwork, 'symmetric')) {
+          message('\nNote that for symmetric networks, effect sizes are for modelType 2 (forcing).')
+        }
+      }
+      
+      #			currentDepObjEffsNames <- paste(effects$shortName[currentDepEffs],
+      #				effects$type[currentDepEffs],effects$interaction1[currentDepEffs],sep=".")
+      #			otherObjEffsNames <- paste(effects$shortName[!currentDepEffs],
+      #				effects$type[!currentDepEffs],effects$interaction1[!currentDepEffs],sep=".")
+      
+      changeStats <- list()
+      if (networkTypes[eff] == "behavior") {
+        toggleProbabilities <- array(0, dim = c(actors, 3, waves))
+      }
+      else {
+        toggleProbabilities <- array(0, dim = c(actors, choices, waves))
+      }
+      for(w in 1:waves) {
+        currentDepEffectContributions <- conts[[1]][[w]][currentDepEffs]
+        if (networkTypes[eff] == "bipartite") {
+          currentDepEffectContributions <- lapply(
+            currentDepEffectContributions,
+            function(x){lapply(x,function(xx){xx[1:choices]})}
+            )
+        }
+        # conts[[1]] is periods by effects by actors by actors
+        currentDepEffectContributions <-
+          sapply(lapply(currentDepEffectContributions, unlist),
+                 matrix, nrow = actors, ncol = choices, byrow = TRUE,
+                 simplify = "array")
+        cdec <- apply(currentDepEffectContributions, c(2,1), as.matrix)
+        # cdec is effects by actors (alters) by actors (egos)
+        if (dim(currentDepEffectContributions)[3] <= 1) { # only one effect
+          cdec <- array(cdec, dim = c(1,dim(cdec)))
+        }
+        rownames(cdec) <- effectNa[currentDepEffs]
+        if (getChangeStatistics) {
+          changeStats[[w]] <- cdec
+        }
+        # replace structural 0s and 1s by NA,
+        # so they are omitted from calculation
+        if (networkTypes[eff] == "oneMode") {
+          #	structuralsw <- structurals[,,w]
+          for (ff in 1:(dim(cdec)[1])) {
+            cdec[ff,,][t(structurals[,,w])] <- NA
+          }
+        }
+        distributions <- apply(cdec, 3,
+                               calculateChoiceProbability, theta[which(currentDepEffs)]) # matrix manipulation should be more efficient solution
+        if (networkTypes[eff] == "behavior") {
+          toggleProbabilities[,,w] <- t(distributions)
+        }
+        else {
+          toggleProbabilities[,,w] <- t(distributions)
+        }
+      }
+    }
+  }
+  toggleProbabilities                                             
+}

--- a/R/sienaMargins.r
+++ b/R/sienaMargins.r
@@ -104,7 +104,8 @@
 ## Are these the change probabilities or the tie probabilities?
 
 ##@expectedChangeProbabilities. Use as RSiena:::expectedChangeProbabilities
-expectedChangeProbabilities <- function(conts, effects, theta, thedata=NULL, effectNames = NULL)
+expectedChangeProbabilities <- function(conts, effects, theta, thedata=NULL, 
+	getChangeStatistics=FALSE, effectNames = NULL)
 {
 	rms <- function(xx){sqrt((1/dim(xx)[2])*rowSums(xx^2,na.rm=TRUE))}
 	waves <- length(conts[[1]])
@@ -229,6 +230,10 @@ message('\nNote that for symmetric networks, effect sizes are for modelType 2 (f
 				# the first row is for the unchanged parameter vector theta,
 				# each of the following has put one element of theta to 0.
 				# for behavior it is a matrix of dim (effects + 1) * 3
+
+			}
+		}
+	}
 distributions
 }
 

--- a/R/sienaMargins.r
+++ b/R/sienaMargins.r
@@ -62,7 +62,7 @@ expectedChangeProbabilities <- function(conts, effects, theta, thedata = NULL,
   effectIds <- paste(effectNa, effectTypes, networkInteraction, sep = ".")
   currentDepName <- ""
   depNumber <- 0
-  for(eff in 1:seq_along(effectIds)) {
+  for(eff in 1:length(effectIds)) { # seq_along throws an error?
     if(networkNames[eff] != currentDepName) {
       currentDepName <- networkNames[eff]
       actors <- length(conts[[1]][[1]][[1]])
@@ -211,8 +211,17 @@ expectedChangeDynamics <- function(data=NULL, theta=NULL, algorithm=NULL, effect
 												"networkName")==currentNetName)
 				{
           cdec <- ans$changeContributions[[1]][[period]][[microStep]]
-          distributions <- apply(cdec, 3,
-                                 calculateChoiceProbability, thetaNoRate[currentNetObjEffs])
+          distributions <- calculateChoiceProbability(
+            cdec,
+            thetaNoRate[currentNetObjEffs]
+          )
+        # Fehler in apply(cdec, 3, calculateChoiceProbability, thetaNoRate[currentNetObjEffs]) : 
+        #  'MARGIN' passt nicht zu dim(X)
+        # Original:
+        # 			distributions <- calculateDistributions(
+        # ans$changeContributions[[1]][[period]][[microStep]],
+        # thetaNoRate[currentNetObjEffs])
+        
         # matrix manipulation should be more efficient solution
         # distributions is an array of actor by choices
         periodExpectedProb[[microStep]] <- t(distributions)

--- a/R/sienaMargins.r
+++ b/R/sienaMargins.r
@@ -80,20 +80,23 @@
 
 ##@softmax Recursive softmax formula, see https://rpubs.com/FJRubio/softmax. Use as RSiena:::softmax
 softmax <- function(par){
-  n.par <- length(par)
-  par1 <- sort(par, decreasing = TRUE)
-  Lk <- par1[1]
-  for (k in 1:(n.par-1)) {
-    Lk <- max(par1[k+1], Lk) + log1p(exp(-abs(par1[k+1] - Lk))) 
-  }
-  val <- exp(par - Lk)
-  return(val)
+#   n.par <- length(par)
+#   par1 <- sort(par, decreasing = TRUE)
+#   Lk <- par1[1]
+#   for (k in 1:(n.par-1)) {
+#     Lk <- max(par1[k+1], Lk) + log1p(exp(-abs(par1[k+1] - Lk))) 
+#   }
+#   val <- exp(par - Lk)
+#   return(val)
+exp(colSums(par, na.rm=TRUE))/
+			sum(exp(colSums(par, na.rm=TRUE)))
 }
 
 ##@calculateChoiceProbability. Use as RSiena:::calculateChoiceProbability (just a simplified calculateDistribution)
 calculateChoiceProbability <- function(effectContributions = NULL, theta = NULL)
 {
-	distributions <- matrix(NA, dim = dim(effectContributions))
+	nchoices <- dim(effectContributions)[2]
+	distributions <- array(NA, dim = c(1,nchoices))
 	the.choices <- !is.na(colSums(effectContributions))
 	if (sum(the.choices) >= 2) ## should produce an error instead of an empty array?
 	{
@@ -241,7 +244,7 @@ message('\nNote that for symmetric networks, effect sizes are for modelType 2 (f
 			}
 		}
 	}
-toggleProbabilities                                             
+distributions                                             
 }            
 
 ## we probably want to extract a tie probability matrix from this


### PR DESCRIPTION
# Description

Added invisible functions (not exported to namespace and only accessible via RSiena:::functionName()) that extract expected change probabilities for the observed data (RSiena:::expectedChangeProbabilities), as well as a first version of RSiena:::expectedChangeDynamics() to extract the change probabilities for each ministep. Both are provisionally stored in a single sienaMargins.r together with helper functions softmax() and calculateChoiceProbability(). All functions are based on code from sienaRI.r and sienaRIDynamics.r. They are meant to provide a starting point and could potentially have similar memory leakage problems as the original sienaRI-functions.

Currently, only expectedChangeProbabilities() does actually calculate all *possible* choices (for the first potential mini-steps in the observed network), while expectedChangeDynamics() does only calculate the choice probabilities for the focal actor in each simulated mini-step. Being able to use the mini-steps actually done in the original fit of the model might also be preferable in the future.

The rate function is ignored for now, the probabilities are all conditional on choosing the respective focal actor.

# Checklist:

## Checks

- [ ] If possible, I have added tests that prove my fix is effective or that my feature works
- [ x ] The package builds on my OS without issues
- [ x ] My changes generate no new warnings

## Documentation
- not made for release yet
