### PR TITLE
Correction for returnChains=TRUE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Encoding: UTF-8
 Package: RSiena
 Type: Package
 Title: Siena - Simulation Investigation for Empirical Network Analysis
-Version: 1.6.9
-Date: 2026-06-10
+Version: 1.6.10
+Date: 2026-06-14
 Authors@R: c(person("Tom A.B.", "Snijders", role = c("aut", "ctb"), comment = c(ORCID = "0000-0003-3157-4157")),
               person("Ruth M.", "Ripley", role = "aut"),
               person("Krists", "Boitmanis", role = c( "aut","ctb")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+2026-06-14
+
+# RSiena 1.6.10
+
+## Changes in RSiena:
+### Bug correction
+  * Running `siena` with `returnChains = TRUE, returnDataFrame = TRUE`
+    corrected.
+### Functionality
+  * Undo sorting of returned data frames for `returnChains=TRUE`
+    (`siena07models.cpp`).
+
 2026-06-10
 
 # RSiena 1.6.9

--- a/man/RSiena-package.Rd
+++ b/man/RSiena-package.Rd
@@ -52,8 +52,8 @@ Bug reports can be submitted at
   \tabular{ll}{
     Package: \tab RSiena\cr
     Type: \tab Package\cr
-    Version: \tab 1.6.9\cr
-    Date: \tab 2026-06-10\cr
+    Version: \tab 1.6.10\cr
+    Date: \tab 2026-06-14\cr
     Depends: \tab R (>= 4.5.0)\cr
     Imports: \tab Matrix, lattice, parallel, MASS, methods, xtable\cr
     Suggests: \tab network, tools, codetools, tcltk\cr

--- a/src/siena07models.cpp
+++ b/src/siena07models.cpp
@@ -416,7 +416,7 @@ SEXP forwardModel(SEXP DERIV, SEXP DATAPTR, SEXP SEEDS,
 				SEXP thisChain;
 				if (returnDataFrame)
 				{
-					thisChain = getChainDFPlus(*(pEpochSimulation->pChain()), true);
+					thisChain = getChainDFPlus(*(pEpochSimulation->pChain()), false);
 				}
 				else
 				{
@@ -665,7 +665,7 @@ SEXP mlPeriod(SEXP DERIV, SEXP DATAPTR, SEXP MODELPTR, SEXP EFFECTSLIST,
 		if (returnDataFrame)
 		{
 			PROTECT(theseValues =
-				Rf_duplicate(getChainDFPlus(*(pMLSimulation->pChain()), true)));
+				Rf_duplicate(getChainDFPlus(*(pMLSimulation->pChain()), false)));
 		}
 		else
 		{


### PR DESCRIPTION
# Description
 - Running `siena` with `returnChains = TRUE, returnDataFrame = TRUE`
    corrected.


# Checklist:

## Checks

- [X] The package builds on my OS without issues
- [X] My changes generate no new warnings

## Documentation

- [X] I have added a description of all changes to this pull request above and to the NEWS.md file
- [X] I have bumped the version in the DESCRIPTION and man/RSiena-package.md files by the appropriate increment:
  - 'major' (incompatible API changes)
  - 'minor' (add functionality in a backwards compatible manner)
  - 'patch' (backwards compatible bug fixes)
